### PR TITLE
Make sure high pointer remains draggable after low pointer is dragged on top of it

### DIFF
--- a/angular-slider.js
+++ b/angular-slider.js
@@ -266,7 +266,7 @@
                   newValue = minValue + (valueRange * newPercent / 100.0);
                   if (range) {
                     if (ref === refLow) {
-                      if (newValue > scope[refHigh]) {
+                      if (newValue >= scope[refHigh]) {
                         ref = refHigh;
                         minPtr.removeClass('active');
                         maxPtr.addClass('active');


### PR DESCRIPTION
Fixes a bug where the high pointer could not be dragged after the lower pointer was dragged on top of it.

To reproduce on http://prajwalkman.github.io/angular-slider/

1) Using the range slider, drag the high pointer to the end of the slider (60)

2) Drag the low pointer to the same value, i.e. on top of the high pointer

3) Drag the low pointer back to any lower value

4) Attempt to drag the high pointer
