### PR TITLE
Ensure numbers remain as numbers.

### DIFF
--- a/src/angular-slider.coffee
+++ b/src/angular-slider.coffee
@@ -24,7 +24,7 @@ roundStep       = (value, precision, step, floor = 0) ->
         else value - remainder
     decimals = Math.pow 10, precision
     roundedValue = steppedValue * decimals / decimals
-    roundedValue.toFixed precision
+    parseFloat roundedValue.toFixed precision
 inputEvents =
     mouse:
         start: 'mousedown'


### PR DESCRIPTION
Previously, the call to toFixed would turn numbers into strings, which was playing havoc with models bound to `<input type="number">` elements.
